### PR TITLE
商品削除機能の実装３

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,6 +37,7 @@ class ItemsController < ApplicationController
 
   def destroy
     @item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, except: [:index, :create, :new]
   before_action :move_to_new, only: :edit
 
   def index
@@ -35,6 +35,9 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    @item.destroy
+  end
 
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :edit]
+  before_action :authenticate_user!, only: [:new, :edit, :destroy]
   before_action :set_item, except: [:index, :create, :new]
   before_action :move_to_new, only: [:edit, :destroy]
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -43,7 +43,8 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:item_name, :explanation, :category_id, :condition_id, :area_id, :postage_id, :arrival_id, :price, :image).merge(user_id: current_user.id)
+    params.require(:item).permit(:item_name, :explanation, :category_id, :condition_id, :area_id, :postage_id, :arrival_id,
+                                 :price, :image).merge(user_id: current_user.id)
   end
 
   def set_item
@@ -51,9 +52,6 @@ class ItemsController < ApplicationController
   end
 
   def move_to_new
-    unless
-      current_user == @item.user
-      redirect_to action: :index
-    end
+    redirect_to action: :index unless current_user == @item.user
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit]
   before_action :set_item, except: [:index, :create, :new]
-  before_action :move_to_new, only: :edit
+  before_action :move_to_new, only: [:edit, :destroy]
 
   def index
     @items = Item.all.order(created_at: :desc)

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
     <% if current_user.id == @item.user.id %>
     <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item.id) , method: :delete, class:"item-destroy" %>
     <% else %>  
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index" 
-  resources :items, only: [:new, :index, :create, :show, :update, :edit]
+  resources :items
 end


### PR DESCRIPTION

What
商品削除機能の実装。出品を取り消したい場合に使用
Why
出品者が出品を取り消したい場合に使用。削除機能がないと望まない売買が成立してしまいトラブルの可能性がある

ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/79abf3eb2b0e3e7f98eed871c6e33d8d